### PR TITLE
Reset

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import FileHandler from "./components/FileHandler.js";
 import FileItem from "./components/FileItem.js";
 import BatchButton from "./components/BatchButton.js";
-import { View, Flex } from "@adobe/react-spectrum";
+import { View, Flex, ActionButton } from "@adobe/react-spectrum";
 import "./App.css";
 import JSZip from "jszip";
 import FileSaver from "file-saver";
@@ -16,15 +16,49 @@ function App() {
     setProgress("processing");
   };
 
+  //Get time string if needed for multiple Zip's
+  const intlOptions = {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  };
+
+  const generateNewTimeString = () => {
+    return new Intl.DateTimeFormat("default", intlOptions)
+      .format(new Date())
+      .replace(/:/g, "");
+  };
+
   //Setup Zip
-  const [zip] = useState(new JSZip());
-  // eslint-disable-next-line
-  const [zipFolder, setZipFolder] = useState(zip.folder("processed"));
+  const [zip, setZip] = useState({});
+  //eslint-disable-next-line
+  const [zipFolder, setZipFolder] = useState({});
+
+  useEffect(() => {
+    let newZip = new JSZip();
+    let newFolder = newZip.folder(generateNewTimeString());
+
+    setZip(newZip);
+    setZipFolder(newFolder);
+    //eslint-disable-next-line
+  }, []);
 
   const completeZip = () => {
     zip.generateAsync({ type: "blob" }).then(blob => {
       FileSaver.saveAs(blob, "shrunk.zip");
     });
+  };
+
+  const resetApp = () => {
+    let newZip = new JSZip();
+    let newFolder = newZip.folder(generateNewTimeString());
+
+    setZip(newZip);
+    setZipFolder(newFolder);
+    setDroppedFiles([]);
+    setFilesComplete(0);
+    setProgress("hold");
   };
 
   useEffect(() => {
@@ -99,6 +133,7 @@ function App() {
                 alignItems="center"
                 justifyContent="end"
               >
+                <ActionButton onPress={resetApp}>Reset</ActionButton>
                 <BatchButton
                   progress={progress}
                   startTheMagick={startTheMagick}

--- a/src/App.js
+++ b/src/App.js
@@ -108,6 +108,7 @@ function App() {
           <FileHandler
             droppedFiles={droppedFiles}
             setDroppedFiles={setDroppedFiles}
+            progress={progress}
           />
         </section>
 

--- a/src/App.js
+++ b/src/App.js
@@ -134,7 +134,9 @@ function App() {
                 alignItems="center"
                 justifyContent="end"
               >
-                <ActionButton onPress={resetApp}>Reset</ActionButton>
+                <ActionButton marginEnd="size-200" onPress={resetApp}>
+                  Reset
+                </ActionButton>
                 <BatchButton
                   progress={progress}
                   startTheMagick={startTheMagick}

--- a/src/components/FileHandler.js
+++ b/src/components/FileHandler.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import DragAndDrop from "./DragAndDrop.js";
 import Upload from "@spectrum-icons/illustrations/Upload";
 import NotFound from "@spectrum-icons/illustrations/NotFound";
+import Timeout from "@spectrum-icons/illustrations/Timeout";
 import {
   View,
   IllustratedMessage,
@@ -9,7 +10,7 @@ import {
   Content,
 } from "@adobe/react-spectrum";
 
-const FileHandler = ({ droppedFiles, setDroppedFiles }) => {
+const FileHandler = ({ droppedFiles, setDroppedFiles, progress }) => {
   const [formats] = useState(["jpg", "jpeg", "png"]);
   const [fileCount, setFileCount] = useState(0);
 
@@ -56,7 +57,23 @@ const FileHandler = ({ droppedFiles, setDroppedFiles }) => {
 
   return (
     <>
-      {!!droppedFiles && droppedFiles.length < 5 ? (
+      {progress !== "hold" ? (
+        <div style={{ display: "inline-block", position: "relative" }}>
+          <View
+            width="75vw"
+            paddingY="10px"
+            borderWidth="thick"
+            borderColor="mid"
+            borderRadius="medium"
+          >
+            <IllustratedMessage>
+              <Timeout />
+              <Heading>Processing Images</Heading>
+              <Content>Choose Reset below to start a new batch</Content>
+            </IllustratedMessage>
+          </View>
+        </div>
+      ) : !!droppedFiles && droppedFiles.length < 5 ? (
         <DragAndDrop handleDropProp={handleDropProp}>
           <View
             width="75vw"

--- a/src/components/FileItem.js
+++ b/src/components/FileItem.js
@@ -140,6 +140,7 @@ const FileItem = ({
             fileInfo={fileInfo}
             setFileInfo={setFileInfo}
             updateRenditionsFileName={updateRenditionsFileName}
+            progress={progress}
           />
           <ActionButton
             isDisabled={progress !== "hold"}

--- a/src/components/FileName.js
+++ b/src/components/FileName.js
@@ -17,6 +17,18 @@ const FileName = ({
     });
   };
 
+  const handleClickOff = () => {
+    setEditing(false);
+    updateRenditionsFileName();
+  };
+
+  const handleKeyPress = e => {
+    if (e.key === "Enter" || e.key === "Escape") {
+      setEditing(false);
+      updateRenditionsFileName();
+    }
+  };
+
   return (
     <>
       {!!editing ? (
@@ -29,6 +41,12 @@ const FileName = ({
               type="text"
               onChange={value => {
                 replaceSpaces(value);
+              }}
+              onBlur={() => {
+                handleClickOff();
+              }}
+              onKeyDown={e => {
+                handleKeyPress(e);
               }}
               value={fileInfo.name}
               isQuiet

--- a/src/components/FileName.js
+++ b/src/components/FileName.js
@@ -32,6 +32,7 @@ const FileName = ({
               }}
               value={fileInfo.name}
               isQuiet
+              aria-label="Update file name"
             />
           </Text>
           <Text>.{fileInfo.type}</Text>

--- a/src/components/FileName.js
+++ b/src/components/FileName.js
@@ -1,7 +1,12 @@
 import React, { useState } from "react";
 import { Heading, Text, TextField, ActionButton } from "@adobe/react-spectrum";
 
-const FileName = ({ fileInfo, setFileInfo, updateRenditionsFileName }) => {
+const FileName = ({
+  fileInfo,
+  setFileInfo,
+  updateRenditionsFileName,
+  progress,
+}) => {
   const [editing, setEditing] = useState(false);
 
   const replaceSpaces = value => {
@@ -47,6 +52,7 @@ const FileName = ({ fileInfo, setFileInfo, updateRenditionsFileName }) => {
           <Text>.{fileInfo.type}</Text>
           <ActionButton
             marginStart="size-100"
+            isDisabled={progress !== "hold"}
             onPress={() => {
               setEditing(true);
             }}


### PR DESCRIPTION
Added Reset option;
Reset creates new Zip and Zip folder with time stamp for name;
This allows for multiple zips to be downloaded without clashing folder names;
Drop Zone and Edit Filename buttons deactivate when progress !== "hold";
When editing FileName if user presses "Enter" or "Escape" or de-focuses the edit field the name changes are saved